### PR TITLE
Fix for multiple packages in for loop

### DIFF
--- a/ellipsis.sh
+++ b/ellipsis.sh
@@ -5,7 +5,7 @@ pkg.install() {
         thomshouse-ellipsis/zsh
     );
     
-    for package in $packages; do
+    for package in ${packages[*]}; do
         ellipsis.list_packages | grep "$ELLIPSIS_PACKAGES/$package" 2>&1 > /dev/null;
         if [ $? -ne 0 ]; then
             $ELLIPSIS_PATH/bin/ellipsis install $package;


### PR DESCRIPTION
Updates the packages variable in the for loop so it returns all the elements instead of only the first one.